### PR TITLE
デプロイ先でfavicon死んでる問題を解決

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,7 +25,7 @@ export default {
         content: process.env.npm_package_description || ""
       }
     ],
-    link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }]
+    link: [{ rel: "icon", type: "image/x-icon", href: "/faciop/favicon.ico" }]
   },
   /*
    ** Customize the progress-bar color


### PR DESCRIPTION
ローカル環境だと死ぬ仕様なので注意